### PR TITLE
Enable unfree packages unconditionally

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -3,9 +3,6 @@ name: build-packages
 
 on: push
 
-env:
-  NIXPKGS_ALLOW_UNFREE: 1
-
 jobs:
   build-libraries:
     runs-on: ubuntu-20.04
@@ -37,7 +34,6 @@ jobs:
       - name: Build package ${{ matrix.pkg }}
         run: |-
           nix -L build \
-              --impure \
               --override-input nixpkgs github:nixos/nixpkgs/${{ matrix.nixpkgs_branch }} \
               --system ${{ matrix.system }} \
               .#${{ matrix.pkg }}

--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ permissions so that `plugdev` group users are allowed to access.
   };
 }
 ```
+
+# Note on unfree packages
+
+Due to limitations of flakes, this flake enables `config.allowUnfree`
+on its import of nixpkgs, meaining that packages can be built without
+otherwise enabling unfree software.

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
           inherit name;
           value = (import nixpkgs {
             inherit system;
+            config.allowUnfree = true;
             overlays = [ self.overlay ];
           })."${name}";
         };


### PR DESCRIPTION
When using pure evaluation, there is no way to enable
nixpkgs.config.allowUnfree, making it unable to build packages.

It seems like this is just a limitation of flakes, so enable
allowUnfree unconditionally in flake.nix, as this flake only has
unfree packages.

---

...though, as I'm just writing this last message before hitting "Create pull request", I realize I can work around this by using an overlay, so it's not 100% necessary.