### PR TITLE
fix: GROUP key takes '=' or ':=' operator, assuming '='

### DIFF
--- a/pkgs/adept2-runtime/default.nix
+++ b/pkgs/adept2-runtime/default.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation rec {
     EOF
 
     cat > $out/etc/udev/rules.d/52-digilent-usb.rules <<EOF
-    ACTION=="add", ATTR{idVendor}=="1443", GROUP+="plugdev", TAG+="uaccess"
-    ACTION=="add", ATTR{idVendor}=="0403", ATTR{manufacturer}=="Digilent", GROUP+="plugdev", TAG+="uaccess", RUN+="$out/sbin/dftdrvdtch %s{busnum} %s{devnum}"
+    ACTION=="add", ATTR{idVendor}=="1443", GROUP="plugdev", TAG+="uaccess"
+    ACTION=="add", ATTR{idVendor}=="0403", ATTR{manufacturer}=="Digilent", GROUP="plugdev", TAG+="uaccess", RUN+="$out/sbin/dftdrvdtch %s{busnum} %s{devnum}"
     EOF
 
     runHook postInstall


### PR DESCRIPTION
The package cannot be installed in my current NixOS setup because of errors in the `52-digilent-usb.rules` file

```
       > Verifying udev rules using udevadm verify...
       > /nix/store/3pzimd8ac9cqpvv42hl58anijki9pdxr-udev-rules/52-digilent-usb.rules:1 GROUP key takes '=' or ':=' operator, assuming '='.
       > /nix/store/3pzimd8ac9cqpvv42hl58anijki9pdxr-udev-rules/52-digilent-usb.rules:2 GROUP key takes '=' or ':=' operator, assuming '='.
       > /nix/store/3pzimd8ac9cqpvv42hl58anijki9pdxr-udev-rules/52-digilent-usb.rules: udev rules check failed.
```

Fix: Changed `+=` to `=` for the `GROUP` key